### PR TITLE
Fixing random integer values solution in NumPy exercises

### DIFF
--- a/3. NumPy exercises.ipynb
+++ b/3. NumPy exercises.ipynb
@@ -325,7 +325,7 @@
    },
    "outputs": [],
    "source": [
-    "np.random.randint(0, 10, size=3)"
+    "np.random.randint(1, 10, size=3)"
    ]
   },
   {

--- a/3. NumPy exercises.ipynb
+++ b/3. NumPy exercises.ipynb
@@ -325,7 +325,7 @@
    },
    "outputs": [],
    "source": [
-    "np.random.randint(10, size=3)"
+    "np.random.randint(0, 10, size=3)"
    ]
   },
   {


### PR DESCRIPTION
Wonderful tutorials but I've noticed this problem.  When prompted:

###Create a numpy array, filled with 3 random integer values between 1 and 10.

The listed solution is

`
np.random.randint(10, size=3)
`

But this code will produce a numpy array of size 3 with integer values between _0_ and 10, not 1 and 10.

The returned array differs each time, of course, but the first time running the solution code in my notebook returned array([0, 4, 0]).

Instead, the solution code should be

`
np.random.randint(1, 10, size=3)
`

to specify 1 as the low value (inclusive) and 10 as the high value (exclusive).  I'm ignoring the ambiguity of "between" in the prompt here, but perhaps clarifying inclusive/exclusive would be helpful too.