### PR TITLE
Replacing Deprecated dtype calls

### DIFF
--- a/3. NumPy exercises.ipynb
+++ b/3. NumPy exercises.ipynb
@@ -115,7 +115,7 @@
    },
    "outputs": [],
    "source": [
-    "np.ones([2,2], dtype=np.int)"
+    "np.ones([2,2], dtype=int)"
    ]
   },
   {
@@ -144,7 +144,7 @@
    },
    "outputs": [],
    "source": [
-    "np.ones([3,2], dtype=np.float)"
+    "np.ones([3,2], dtype=float)"
    ]
   },
   {
@@ -173,7 +173,7 @@
    },
    "outputs": [],
    "source": [
-    "X = np.arange(4, dtype=np.int)\n",
+    "X = np.arange(4, dtype=int)\n",
     "\n",
     "np.ones_like(X)"
    ]
@@ -204,7 +204,7 @@
    },
    "outputs": [],
    "source": [
-    "X = np.array([[1,2,3], [4,5,6]], dtype=np.int)\n",
+    "X = np.array([[1,2,3], [4,5,6]], dtype=int)\n",
     "\n",
     "np.zeros_like(X)"
    ]
@@ -235,7 +235,7 @@
    },
    "outputs": [],
    "source": [
-    "np.ones([4,4], dtype=np.int) * 5"
+    "np.ones([4,4], dtype=int) * 5"
    ]
   },
   {
@@ -264,7 +264,7 @@
    },
    "outputs": [],
    "source": [
-    "X = np.array([[2,3], [6,2]], dtype=np.int)\n",
+    "X = np.array([[2,3], [6,2]], dtype=int)\n",
     "\n",
     "np.ones_like(X) * 7"
    ]
@@ -417,7 +417,7 @@
    },
    "outputs": [],
    "source": [
-    "X = np.array([5,2,3], dtype=np.int)\n",
+    "X = np.array([5,2,3], dtype=int)\n",
     "print(X, id(X))\n",
     "\n",
     "Y = np.copy(X)\n",
@@ -1059,7 +1059,7 @@
    "source": [
     "X = [-5, -3, 0, 10, 40]\n",
     "\n",
-    "np.array(X, np.float)"
+    "np.array(X, float)"
    ]
   },
   {


### PR DESCRIPTION
<np>.int or <np>.float is deprecated and no longer callable.

Replaced with dtype=int or dtype=float

Error: 
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. 
...
The aliases was originally deprecated in NumPy 1.20;